### PR TITLE
Add dynamic month, and year dropdown options

### DIFF
--- a/script.js
+++ b/script.js
@@ -35,7 +35,7 @@ let currentYear = new Date().getFullYear()
 const yearDropdown = () => {
     const selectYear = document.getElementById("year")
     selectYear.innerHTML = ""
-    for (let i = 1990; i <= 2100; i++) {
+    for (let i = 1900; i <= 2100; i++) {
         const option = document.createElement("option")
         option.textContent = i
         option.value = i


### PR DESCRIPTION
Populate Month (0–11) and Year (1990–2100) dropdowns via JS

Default selects the current month/year and clears options before rebuilding